### PR TITLE
priorize "xoauth2" over "login" to support both plug-ins simultaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,32 @@ smtp_sasl_security_options =
 smtp_sasl_mechanism_filter = xoauth2
 ```
 
+Alternatively, you could specify multiple mechanisms, i.e. 
+```
+smtp_sasl_mechanism_filter = xoauth2,login
+```
+
+The above used to cause problems, because both "xoauth2" and the "login"
+plug-in (as is used for many older, not-yet-OAuth2 providers) had the
+same "SSF" setting of "0". This made SASL's automatic detection of which
+plug-in to use non-deterministic. Now, with the higher SSF of "60" for
+"xoauth2", providers offering OAUTH2 will be handled via the xoauth2 plug-in.
+
+You can check the effective value by calling "pluginviewer -c", look for
+the "SSF" value:
+```
+Plugin "sasl-xoauth2" [loaded],         API version: 4
+        SASL mechanism: XOAUTH2, best SSF: 60
+        security flags: NO_ANONYMOUS|PASS_CREDENTIALS
+        features: WANT_CLIENT_FIRST|PROXY_AUTHENTICATION
+Plugin "login" [loaded],        API version: 4
+        SASL mechanism: LOGIN, best SSF: 0
+        security flags: NO_ANONYMOUS|PASS_CREDENTIALS
+        features: SERVER_FIRST
+```
+See https://www.cyrusimap.org/sasl/sasl/authentication_mechanisms.html#authentication-mechanisms for details on the fields.
+
+
 While you're at it, enable TLS:
 
 ```

--- a/src/module.cc
+++ b/src/module.cc
@@ -50,7 +50,7 @@ void mech_dispose(void *context, const sasl_utils_t *utils) {
 
 sasl_client_plug_t s_plugin = {
     /* mech_name = */ "XOAUTH2",
-    /* max_ssf = */ 0,
+    /* max_ssf = */ 60,
     /* security_flags = */ SASL_SEC_NOANONYMOUS | SASL_SEC_PASS_CREDENTIALS,
     /* features = */ SASL_FEAT_WANT_CLIENT_FIRST | SASL_FEAT_ALLOWS_PROXY,
     /* required_prompts = */ nullptr,


### PR DESCRIPTION
SASL may be used in multi-provider scenarios, where some providers offer
"xoauth2" for authentication, where other providers still require "login" authentication.

Configuring the according postfix main.cf statement accordingly

    smtp_sasl_mechanism_filter = xoauth2,login

may lead to non-deterministic behavior, because both plug-ins specified the same "SSF"
value of "0" (security strength factor) and sasl could not reliable determine which
plug-in to prefer.

With the higher SSF of 60, xoauth2 now is prefered over those plug-ins specifying only
a default SSF and over GSSAPI, too (https://www.cyrusimap.org/sasl/sasl/authentication_mechanisms.html#authentication-mechanisms)