### PR TITLE
Install the update-ca-certificates hook script in Ubuntu package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build
+/packaging-output

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,6 @@ add_subdirectory(src)
 
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}-${PROJECT_VERSION}")
 set(CPACK_SOURCE_GENERATOR "TGZ")
-set(CPACK_SOURCE_IGNORE_FILES "/build/;/packaging/;/packaging-build/;/packaging-output/;/packaging-scripts/;/.git/;.clang-format;~$;${CPACK_SOURCE_IGNORE_FILES}")
+set(CPACK_SOURCE_IGNORE_FILES "/build/;/packaging/;/packaging-build/;/packaging-output/;/packaging-scripts/;/.git/;/.gitignore;.clang-format;~$;${CPACK_SOURCE_IGNORE_FILES}")
 
 include(CPack)

--- a/README.md
+++ b/README.md
@@ -145,15 +145,11 @@ $ sudo mkdir -p /var/spool/postfix/etc/ssl/certs
 $ sudo cp /etc/ssl/certs/ca-certificates.crt /var/spool/postfix/etc/ssl/certs/ca-certificates.crt
 ```
 
-On Debian and Ubuntu systems, you can ensure the certificates are copied whenever the system certificates are updated by saving the following as `/etc/ca-certificates/update.d/postfix-sasl-xoauth2`:
-
-```
-#!/bin/sh
-
-cp /etc/ssl/certs/ca-certificates.crt /var/spool/postfix/etc/ssl/certs/ca-certificates.crt
-```
-
-This script will be automatically run by `update-ca-certificates`.
+The Debian and Ubuntu packages install a script that is automatically run by
+`update-ca-certificates` to ensure the certificates are copied whenever the
+system certificates are updated:
+`/etc/ca-certificates/update.d/postfix-sasl-xoauth2`. It is also run when
+the package is installed.
 
 #### A Note on postmulti
 

--- a/packaging/ubuntu-focal/control
+++ b/packaging/ubuntu-focal/control
@@ -13,5 +13,5 @@ Standards-Version: 4.1.3
 
 Package: sasl-xoauth2
 Architecture: any
-Depends: libsasl2-2, ${shlibs:Depends}, ${misc:Depends}
+Depends: libsasl2-2, ca-certificates, ${shlibs:Depends}, ${misc:Depends}
 Description: SASL extension for XOAUTH2.

--- a/packaging/ubuntu-focal/install
+++ b/packaging/ubuntu-focal/install
@@ -1,0 +1,1 @@
+scripts/update-ca-certificates.sh /etc/ca-certificates/update.d/postfix-sasl-xoauth2

--- a/packaging/ubuntu-focal/sasl-xoauth2.postinst
+++ b/packaging/ubuntu-focal/sasl-xoauth2.postinst
@@ -1,0 +1,2 @@
+#!/bin/sh
+update-ca-certificates

--- a/scripts/update-ca-certificates.sh
+++ b/scripts/update-ca-certificates.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Don't give an error if, for example, postfix is not installed.
+cp /etc/ssl/certs/ca-certificates.crt /var/spool/postfix/etc/ssl/certs/ca-certificates.crt || true


### PR DESCRIPTION
Rather than instruct the user how to install it manually, install it as part
of the package.