### PR TITLE
Adding proxy support for token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,23 @@ Leave `client_secret` blank. Additionally, explicitly set the token endpoint (`s
 
 We'll also need these credentials in the next step.
 
+### Proxy support 
+
+In case the system is behind a corporate web proxy you can configure a proxy that is used by the curl library when refreshing the token.
+
+```json
+{
+  "client_id": "client ID goes here",
+  "client_secret": "",
+  "token_endpoint": "https://login.microsoftonline.com/consumers/oauth2/v2.0/token",
+  "proxy" : "http://proxy:8080"
+}
+```
+
+For supported proxy schemes please refer to the [curl library documentation](https://curl.se/libcurl/c/CURLOPT_PROXY.html):
+
+```
+
 #### A Note on Token Endpoints
 
 The endpoint above

--- a/README.md
+++ b/README.md
@@ -291,9 +291,7 @@ In case the system is behind a corporate web proxy you can configure a proxy tha
 }
 ```
 
-For supported proxy schemes please refer to the [curl library documentation](https://curl.se/libcurl/c/CURLOPT_PROXY.html):
-
-```
+For supported proxy schemes please refer to the [curl library documentation](https://curl.se/libcurl/c/CURLOPT_PROXY.html)
 
 #### A Note on Token Endpoints
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -151,6 +151,9 @@ int Config::Init(const Json::Value &root) {
     err = Fetch(root, "token_endpoint", true, &token_endpoint_);
     if (err != SASL_OK) return err;
 
+    err = Fetch(root, "proxy", true, &proxy_);
+    if (err != SASL_OK) return err;
+
     return 0;
 
   } catch (const std::exception &e) {

--- a/src/config.h
+++ b/src/config.h
@@ -35,6 +35,7 @@ class Config {
   bool log_to_syslog_on_failure() const { return log_to_syslog_on_failure_; }
   bool log_full_trace_on_failure() const { return log_full_trace_on_failure_; }
   std::string token_endpoint() const { return token_endpoint_; }
+  std::string proxy() const { return proxy_; }
 
  private:
   Config() = default;
@@ -46,6 +47,7 @@ class Config {
   bool log_to_syslog_on_failure_ = true;
   bool log_full_trace_on_failure_ = false;
   std::string token_endpoint_ = "https://accounts.google.com/o/oauth2/token";
+  std::string proxy_ = "";
 };
 
 }  // namespace sasl_xoauth2

--- a/src/http.cc
+++ b/src/http.cc
@@ -87,7 +87,7 @@ void SetHttpInterceptForTesting(HttpIntercept intercept) {
   s_intercept = intercept;
 }
 
-int HttpPost(const std::string &url, const std::string &data,
+int HttpPost(const std::string &url, const std::string &data, const std::string &proxy,
              long *response_code, std::string *response, std::string *error) {
   if (s_intercept)
     return s_intercept(url, data, response_code, response, error);
@@ -119,6 +119,7 @@ int HttpPost(const std::string &url, const std::string &data,
   // HTTP.
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, true);
   curl_easy_setopt(curl, CURLOPT_USERAGENT, kUserAgent);
+  curl_easy_setopt(curl, CURLOPT_PROXY, proxy.c_str());
   curl_easy_setopt(curl, CURLOPT_POST, true);
   curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE,
                    static_cast<curl_off_t>(context.to_server_size()));

--- a/src/http.cc
+++ b/src/http.cc
@@ -116,10 +116,10 @@ int HttpPost(const std::string &url, const std::string &data, const std::string 
   // Network.
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
 
-  // HTTP.
+    // HTTP.
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, true);
   curl_easy_setopt(curl, CURLOPT_USERAGENT, kUserAgent);
-  curl_easy_setopt(curl, CURLOPT_PROXY, proxy.c_str());
+  if (!proxy.empty()) curl_easy_setopt(curl, CURLOPT_PROXY, proxy.c_str());
   curl_easy_setopt(curl, CURLOPT_POST, true);
   curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE,
                    static_cast<curl_off_t>(context.to_server_size()));

--- a/src/http.cc
+++ b/src/http.cc
@@ -116,7 +116,7 @@ int HttpPost(const std::string &url, const std::string &data, const std::string 
   // Network.
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
 
-    // HTTP.
+  // HTTP.
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, true);
   curl_easy_setopt(curl, CURLOPT_USERAGENT, kUserAgent);
   if (!proxy.empty()) curl_easy_setopt(curl, CURLOPT_PROXY, proxy.c_str());

--- a/src/http.h
+++ b/src/http.h
@@ -28,7 +28,7 @@ using HttpIntercept = std::function<int(
 
 void SetHttpInterceptForTesting(HttpIntercept intercept);
 
-int HttpPost(const std::string &url, const std::string &data,
+int HttpPost(const std::string &url, const std::string &data, const std::string &proxy,
              long *response_code, std::string *response, std::string *error);
 
 }  // namespace sasl_xoauth2

--- a/src/token_store.cc
+++ b/src/token_store.cc
@@ -101,6 +101,10 @@ int TokenStore::Refresh() {
       (override_token_endpoint_.empty() ? Config::Get()->token_endpoint()
                                         : override_token_endpoint_);
 
+  const std::string proxy =
+      (override_proxy_.empty() ? Config::Get()->proxy()
+                                        : override_proxy_);
+
   const std::string request =
       std::string("client_id=") + client_id +
       "&client_secret=" + client_secret +
@@ -113,7 +117,7 @@ int TokenStore::Refresh() {
 
   std::string http_error;
   int err =
-      HttpPost(token_endpoint, request, &response_code, &response, &http_error);
+      HttpPost(token_endpoint, request, proxy, &response_code, &response, &http_error);
   if (err != SASL_OK) {
     log_->Write("TokenStore::Refresh: http error: %s", http_error.c_str());
     return err;

--- a/src/token_store.cc
+++ b/src/token_store.cc
@@ -190,6 +190,7 @@ int TokenStore::Read() {
     ReadOverride(root, "client_id", &override_client_id_);
     ReadOverride(root, "client_secret", &override_client_secret_);
     ReadOverride(root, "token_endpoint", &override_token_endpoint_);
+    ReadOverride(root, "proxy", &override_proxy_);
 
     refresh_ = root["refresh_token"].asString();
     if (root.isMember("access_token"))
@@ -218,6 +219,7 @@ int TokenStore::Write() {
     WriteOverride("client_id", override_client_id_, &root);
     WriteOverride("client_secret", override_client_secret_, &root);
     WriteOverride("token_endpoint", override_token_endpoint_, &root);
+    WriteOverride("proxy", override_proxy_, &root);
 
     std::ofstream file(new_path);
     if (!file.good()) {

--- a/src/token_store.h
+++ b/src/token_store.h
@@ -46,6 +46,7 @@ class TokenStore {
   std::string override_client_id_;
   std::string override_client_secret_;
   std::string override_token_endpoint_;
+  std::string override_proxy_;
 
   std::string access_;
   std::string refresh_;


### PR DESCRIPTION
Hi, 

I added proxy support for refreshing the token as I plan to use it behind a corporate web proxy and curl library fully supports that scenario. Actually I was not really sure if I need to add override support for this parameter too ...

Thanks and greetings