### PR TITLE
Add ca_bundle_file and ca_certs_dir config options

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -38,6 +38,8 @@ class Config {
   bool log_full_trace_on_failure() const { return log_full_trace_on_failure_; }
   std::string token_endpoint() const { return token_endpoint_; }
   std::string proxy() const { return proxy_; }
+  std::string ca_bundle_file() const { return ca_bundle_file_; }
+  std::string ca_certs_dir() const { return ca_certs_dir_; }
 
  private:
   Config() = default;
@@ -50,6 +52,8 @@ class Config {
   bool log_full_trace_on_failure_ = false;
   std::string token_endpoint_ = "https://accounts.google.com/o/oauth2/token";
   std::string proxy_ = "";
+  std::string ca_bundle_file_ = "";
+  std::string ca_certs_dir_ = "";
 };
 
 }  // namespace sasl_xoauth2

--- a/src/http.cc
+++ b/src/http.cc
@@ -89,7 +89,9 @@ void SetHttpInterceptForTesting(HttpIntercept intercept) {
 
 int HttpPost(const std::string &url, const std::string &data,
              const std::string &proxy, long *response_code,
-             std::string *response, std::string *error) {
+             std::string *response, std::string *error,
+             const std::string &ca_bundle_file,
+             const std::string &ca_certs_dir) {
   if (s_intercept)
     return s_intercept(url, data, response_code, response, error);
 
@@ -116,6 +118,14 @@ int HttpPost(const std::string &url, const std::string &data,
 
   // Network.
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+
+  // Certs.
+  if (ca_certs_dir.empty()) {
+    if (!ca_bundle_file.empty())
+      curl_easy_setopt(curl, CURLOPT_CAINFO, ca_bundle_file.c_str());
+  } else {
+    curl_easy_setopt(curl, CURLOPT_CAPATH, ca_certs_dir.c_str());
+  }
 
   // HTTP.
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, true);

--- a/src/http.cc
+++ b/src/http.cc
@@ -88,10 +88,9 @@ void SetHttpInterceptForTesting(HttpIntercept intercept) {
 }
 
 int HttpPost(const std::string &url, const std::string &data,
-             const std::string &proxy, long *response_code,
-             std::string *response, std::string *error,
-             const std::string &ca_bundle_file,
-             const std::string &ca_certs_dir) {
+             const std::string &proxy, const std::string &ca_bundle_file,
+             const std::string &ca_certs_dir, long *response_code,
+             std::string *response, std::string *error) {
   if (s_intercept)
     return s_intercept(url, data, response_code, response, error);
 
@@ -121,8 +120,11 @@ int HttpPost(const std::string &url, const std::string &data,
 
   // Certs.
   if (ca_certs_dir.empty()) {
-    if (!ca_bundle_file.empty())
+    if (ca_bundle_file.empty()) {
+      // Use default CA location.
+    } else {
       curl_easy_setopt(curl, CURLOPT_CAINFO, ca_bundle_file.c_str());
+    }
   } else {
     curl_easy_setopt(curl, CURLOPT_CAPATH, ca_certs_dir.c_str());
   }

--- a/src/http.h
+++ b/src/http.h
@@ -29,10 +29,9 @@ using HttpIntercept = std::function<int(
 void SetHttpInterceptForTesting(HttpIntercept intercept);
 
 int HttpPost(const std::string &url, const std::string &data,
-             const std::string &proxy, long *response_code,
-             std::string *response, std::string *error,
-             const std::string &ca_bundle_file,
-             const std::string &ca_certs_dir);
+             const std::string &proxy, const std::string &ca_bundle_file,
+             const std::string &ca_certs_dir, long *response_code,
+             std::string *response, std::string *error);
 
 }  // namespace sasl_xoauth2
 

--- a/src/http.h
+++ b/src/http.h
@@ -30,7 +30,9 @@ void SetHttpInterceptForTesting(HttpIntercept intercept);
 
 int HttpPost(const std::string &url, const std::string &data,
              const std::string &proxy, long *response_code,
-             std::string *response, std::string *error);
+             std::string *response, std::string *error,
+             const std::string &ca_bundle_file,
+             const std::string &ca_certs_dir);
 
 }  // namespace sasl_xoauth2
 

--- a/src/token_store.cc
+++ b/src/token_store.cc
@@ -104,6 +104,14 @@ int TokenStore::Refresh() {
   const std::string proxy =
       (override_proxy_.empty() ? Config::Get()->proxy() : override_proxy_);
 
+  const std::string ca_bundle_file =
+      (override_ca_bundle_file_.empty() ? Config::Get()->ca_bundle_file()
+                                        : override_ca_bundle_file_);
+
+  const std::string ca_certs_dir =
+      (override_ca_certs_dir_.empty() ? Config::Get()->ca_certs_dir()
+                                      : override_ca_certs_dir_);
+
   const std::string request =
       std::string("client_id=") + client_id +
       "&client_secret=" + client_secret +
@@ -116,7 +124,7 @@ int TokenStore::Refresh() {
 
   std::string http_error;
   int err = HttpPost(token_endpoint, request, proxy, &response_code, &response,
-                     &http_error);
+                     &http_error, ca_bundle_file, ca_certs_dir);
   if (err != SASL_OK) {
     log_->Write("TokenStore::Refresh: http error: %s", http_error.c_str());
     return err;
@@ -190,6 +198,8 @@ int TokenStore::Read() {
     ReadOverride(root, "client_secret", &override_client_secret_);
     ReadOverride(root, "token_endpoint", &override_token_endpoint_);
     ReadOverride(root, "proxy", &override_proxy_);
+    ReadOverride(root, "ca_bundle_file", &override_ca_bundle_file_);
+    ReadOverride(root, "ca_certs_dir", &override_ca_certs_dir_);
 
     refresh_ = root["refresh_token"].asString();
     if (root.isMember("access_token"))
@@ -224,6 +234,8 @@ int TokenStore::Write() {
     WriteOverride("client_secret", override_client_secret_, &root);
     WriteOverride("token_endpoint", override_token_endpoint_, &root);
     WriteOverride("proxy", override_proxy_, &root);
+    WriteOverride("ca_bundle_file", override_ca_bundle_file_, &root);
+    WriteOverride("ca_certs_dir", override_ca_certs_dir_, &root);
 
     std::ofstream file(new_path);
     if (!file.good()) {

--- a/src/token_store.cc
+++ b/src/token_store.cc
@@ -123,8 +123,8 @@ int TokenStore::Refresh() {
   log_->Write("TokenStore::Refresh: request: %s", request.c_str());
 
   std::string http_error;
-  int err = HttpPost(token_endpoint, request, proxy, &response_code, &response,
-                     &http_error, ca_bundle_file, ca_certs_dir);
+  int err = HttpPost(token_endpoint, request, proxy, ca_bundle_file,
+                     ca_certs_dir, &response_code, &response, &http_error);
   if (err != SASL_OK) {
     log_->Write("TokenStore::Refresh: http error: %s", http_error.c_str());
     return err;

--- a/src/token_store.h
+++ b/src/token_store.h
@@ -49,6 +49,8 @@ class TokenStore {
   std::string override_client_secret_;
   std::string override_token_endpoint_;
   std::string override_proxy_;
+  std::string override_ca_bundle_file_;
+  std::string override_ca_certs_dir_;
 
   std::string access_;
   std::string refresh_;


### PR DESCRIPTION
This patch (potentially) fixes tarickb/sasl-xoauth2#14.

Indeed, this patch introduces the "ca_bundle_file" and "ca_certs_dir" configuration keys.

From now on, "ca_bundle_file" will be plumbed into CURLOPT_CAINFO and "ca_certs_dir" into CURLOPT_CAPATH. However, when the value of "ca_certs_dir" is empty, we fallback to "ca_bundle_file" if it's not empty either.