### PR TITLE
Feature enhanced config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
+/cmake-build-debug
 /build
 /packaging-build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 /build
 /packaging-build

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ sasl-xoauth2 also provides two configuration variables, `ca_bundle_file` and
 libraries will look for a CA certificate bundle (for `ca_bundle_file`) or a set
 of CA certificates (for `ca_certs_dir`). Specify one or the other, but not both.
 
+**Remember curl expect a new line after the last certificate in the bundle. If it is missed curl aborts with an read error.**
+
 #### A Note on postmulti
 
 [@jamenlang](https://github.com/jamenlang) has provided a [very helpful
@@ -402,6 +404,25 @@ or:
 ```
 $ sudo chown -R postfix:postfix /var/spool/postfix/etc/tokens
 ```
+
+### Outlook/Office 365 Configuration (Client Credentials Flow)
+
+The initial work at azure entra platform for creating an app is the same like the device flow.
+For preventing initial interaction with a browser we add a secret to the app and can use it for the client credential flow.
+
+Store the client ID and secret in `/etc/sasl-xoauth2.conf`:
+
+```json
+{
+  "client_id": "client ID goes here",
+  "client_secret": "client secret goes here",
+  "use_client_credentials": "true",
+  "scope": "https://outlook.office365.com/.default",
+  "token_endpoint": "https://login.microsoftonline.com/<YOUR TENANT ID>/oauth2/v2.0/token"
+}
+```
+
+This flow prevents the need of a refresh token in the token answer.
 
 ### Outlook/Office 365 Configuration (Legacy Client) (Deprecated)
 

--- a/docs/sasl-xoauth2.conf.5.md
+++ b/docs/sasl-xoauth2.conf.5.md
@@ -66,6 +66,14 @@ The top-level JSON object can contain the following keys:
 
 : if set, overrides the default 10 second refresh window with the specified time in seconds (integer)
 
+`manage_token_externally`
+
+: if set, especially in the token file, the plugin takes the token as is
+
+`use_client_credentials`
+
+: if set, the client credentials grant flow is used, instead of the refresh_token flow
+
 # TOKEN FILE
 
 In addition to this file, `sasl-xoauth2` relies on a "token file" which it updates independently.

--- a/docs/sasl-xoauth2.conf.5.md
+++ b/docs/sasl-xoauth2.conf.5.md
@@ -34,6 +34,10 @@ The top-level JSON object can contain the following keys:
 
 : authenticates this client for OAuth 2 token requests; world-readable by default (but see below to place this in token files instead)
 
+`scope`
+
+: if the client credentials grant is used, we need a scope. Specially for office365.com where the default scope should be: `https://outlook.office365.com/.default` 
+
 `always_log_to_syslog`
 
 : always write plugin log messages to syslog, even for successful runs; may contain tokens/secrets (defaults to "no")
@@ -56,7 +60,7 @@ The top-level JSON object can contain the following keys:
 
 `ca_bundle_file`
 
-: if set, overrides CURL's default certificate-authority bundle file
+: if set, overrides CURL's default certificate-authority bundle file. **Remember curl expect a new line after the last certificate in the bundle**.
 
 `ca_certs_dir`
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -151,6 +151,9 @@ int Config::Init(const Json::Value &root) {
     err = Fetch(root, "client_secret", false, &client_secret_);
     if (err != SASL_OK) return err;
 
+    err = Fetch(root, "scope", true, &scope_);
+    if (err != SASL_OK) return err;
+
     err = Fetch(root, "always_log_to_syslog", true,
                 &always_log_to_syslog_);
     if (err != SASL_OK) return err;

--- a/src/config.cc
+++ b/src/config.cc
@@ -178,6 +178,14 @@ int Config::Init(const Json::Value &root) {
     err = Fetch(root, "ca_certs_dir", true, &ca_certs_dir_);
     if (err != SASL_OK) return err;
 
+    err = Fetch(root, "manage_token_externally", true,
+                &manage_token_externally_);
+    if (err != SASL_OK) return err;
+
+    err = Fetch(root, "use_client_credentials", true,
+            &use_client_credentials_);
+    if (err != SASL_OK) return err;
+
     return 0;
 
   } catch (const std::exception &e) {

--- a/src/config.h
+++ b/src/config.h
@@ -37,6 +37,8 @@ class Config {
   bool always_log_to_syslog() const { return always_log_to_syslog_; }
   bool log_to_syslog_on_failure() const { return log_to_syslog_on_failure_; }
   bool log_full_trace_on_failure() const { return log_full_trace_on_failure_; }
+  bool manage_token_externally() const { return manage_token_externally_; }
+  bool use_client_credentials() const { return use_client_credentials_; }
   std::string token_endpoint() const { return token_endpoint_; }
   std::string proxy() const { return proxy_; }
   std::string ca_bundle_file() const { return ca_bundle_file_; }
@@ -53,6 +55,8 @@ class Config {
   bool always_log_to_syslog_ = false;
   bool log_to_syslog_on_failure_ = true;
   bool log_full_trace_on_failure_ = false;
+  bool manage_token_externally_ = false;
+  bool use_client_credentials_ = false;
   std::string token_endpoint_ = "https://accounts.google.com/o/oauth2/token";
   std::string proxy_ = "";
   std::string ca_bundle_file_ = "";

--- a/src/config.h
+++ b/src/config.h
@@ -34,6 +34,7 @@ class Config {
 
   std::string client_id() const { return client_id_; }
   std::string client_secret() const { return client_secret_; }
+  std::string scope() const { return scope_; }
   bool always_log_to_syslog() const { return always_log_to_syslog_; }
   bool log_to_syslog_on_failure() const { return log_to_syslog_on_failure_; }
   bool log_full_trace_on_failure() const { return log_full_trace_on_failure_; }
@@ -52,6 +53,7 @@ class Config {
 
   std::string client_id_;
   std::string client_secret_;
+  std::string scope_;
   bool always_log_to_syslog_ = false;
   bool log_to_syslog_on_failure_ = true;
   bool log_full_trace_on_failure_ = false;

--- a/src/token_store.cc
+++ b/src/token_store.cc
@@ -283,11 +283,11 @@ int TokenStore::Write() {
     if (override_refresh_window_) {
       root["refresh_window"] = std::to_string(*override_refresh_window_);
     }
-    if (use_client_credentials_) {
-      root["use_client_credentials"] = use_client_credentials_ ? "true" : "false";
+    if (use_client_credentials_.has_value()) {
+      root["use_client_credentials"] = use_client_credentials_.value_or(false) ? "true" : "false";
     }
-    if (manage_token_externally_) {
-      root["manage_token_externally"] = manage_token_externally_ ? "true" : "false";
+    if (manage_token_externally_.has_value()) {
+      root["manage_token_externally"] = manage_token_externally_.value_or(false) ? "true" : "false";
     }
 
     std::ofstream file(new_path);

--- a/src/token_store.h
+++ b/src/token_store.h
@@ -55,6 +55,7 @@ class TokenStore {
   std::optional<std::string> override_proxy_;
   std::optional<std::string> override_ca_bundle_file_;
   std::optional<std::string> override_ca_certs_dir_;
+  std::optional<std::string> override_scope_;
   std::optional<int> override_refresh_window_ = 0;
   std::optional<bool> manage_token_externally_ = false;
   std::optional<bool> use_client_credentials_ = false;

--- a/src/token_store.h
+++ b/src/token_store.h
@@ -56,9 +56,11 @@ class TokenStore {
   std::optional<std::string> override_ca_bundle_file_;
   std::optional<std::string> override_ca_certs_dir_;
   std::optional<int> override_refresh_window_ = 0;
+  std::optional<bool> manage_token_externally_ = false;
+  std::optional<bool> use_client_credentials_ = false;
 
   std::string access_;
-  std::string refresh_;
+  std::optional<std::string> refresh_;
   std::optional<std::string> user_;
   time_t expiry_ = 0;
 


### PR DESCRIPTION
- you have in the pipeline an old pull request for managing tokens external with or without a refresh token, and use only the access_token for authentication
- on my use case with serveral office365.com accounts as relay, I have to handle oauth clients with client credentials flow, and I was not able to use the device flow for some tenants
- I have add some config vars for this case (config.h / config.cc)
- I allow the same vars for override (token_store.h / token_store.cc)
- add the description in the sasl-xoauth2.conf mark down
- and add a very short description in the read me

### TODO

- Open is in from my side the enhancement for the sasl-xoauth2-tool, my proposal is to allow calling with a config json, to prevent blooting out all possible options to the command line