### PR TITLE
test_config.cc: include libgen.h for basename(3)

### DIFF
--- a/src/test_config.cc
+++ b/src/test_config.cc
@@ -1,4 +1,5 @@
 #include <getopt.h>
+#include <libgen.h>
 #include <sasl/sasl.h>
 #include <string.h>
 


### PR DESCRIPTION
On musl systems basename(3) requires libgen.h. This file fails to compile without this header included.