### PR TITLE
feat: add national cloud support for M365 sovereign environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,53 @@ tenant ID. See [Microsoft's OAuth protocol
 documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints)
 for more on this.
 
+#### A Note on National Clouds (US Government, 21Vianet)
+
+Microsoft operates separate cloud environments for government and sovereign
+regions. These use different login endpoints and SMTP scope domains. The
+`sasl-xoauth2-tool` supports the following environments via the `--cloud` flag:
+
+| Cloud | `--cloud` value | Login endpoint | SMTP scope domain |
+|---|---|---|---|
+| Public (default) | `public` | `login.microsoftonline.com` | `outlook.office.com` |
+| US Government GCC High | `usgov` | `login.microsoftonline.us` | `outlook.office365.us` |
+| US Government DoD | `usgov-dod` | `login.microsoftonline.us` | `outlook.office365.us` |
+| China (21Vianet) | `china` | `login.partner.microsoftonline.cn` | `partner.outlook.cn` |
+
+For US Government, the configuration file should use the corresponding token
+endpoint:
+
+```json
+{
+  "client_id": "client ID goes here",
+  "client_secret": "",
+  "token_endpoint": "https://login.microsoftonline.us/TENANT_ID/oauth2/v2.0/token"
+}
+```
+
+For China (21Vianet):
+
+```json
+{
+  "client_id": "client ID goes here",
+  "client_secret": "",
+  "token_endpoint": "https://login.partner.microsoftonline.cn/TENANT_ID/oauth2/v2.0/token"
+}
+```
+
+If your cloud environment is not yet listed, you can override individual
+settings with `--login-base` and `--scope`:
+
+```shell
+$ sasl-xoauth2-tool get-token outlook \
+    PATH_TO_TOKENS_FILE \
+    --client-id=CLIENT_ID \
+    --tenant=TENANT_ID \
+    --login-base=https://login.microsoftonline.us \
+    --scope="openid offline_access https://outlook.office365.us/SMTP.Send" \
+    --use-device-flow
+```
+
 #### Initial Access Token
 
 The sasl-xoauth2 package includes a script that can assist in the generation of
@@ -371,6 +418,9 @@ $ sasl-xoauth2-tool get-token outlook \
     --use-device-flow
 To sign in, use a web browser to open the page https://www.microsoft.com/link and enter the code REDACTED to authenticate.
 ```
+
+For national clouds, add the `--cloud` flag (e.g. `--cloud=usgov` or
+`--cloud=china`).
 
 If using a tenant other than `consumers`, pass `--tenant=common`,
 `--tenant=organizations`, or `--tenant=TENANT_ID`. The client ID will
@@ -448,7 +498,9 @@ for use with consumer Outlook accounts. For other types of accounts it may be
 necessary to replace `consumers` with `common`, `organizations`, or a specific
 tenant ID. See [Microsoft's OAuth protocol
 documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints)
-for more on this.
+for more on this. For national clouds (US Government, 21Vianet), see
+[A Note on National Clouds](#a-note-on-national-clouds-us-government-21vianet)
+in the Device Flow section above.
 
 #### Initial Access Token
 

--- a/docs/sasl-xoauth2.conf.5.md
+++ b/docs/sasl-xoauth2.conf.5.md
@@ -48,7 +48,10 @@ The top-level JSON object can contain the following keys:
 
 `token_endpoint`
 
-: URL to use when requesting tokens; defaults to Google, must be overridden for use with Microsoft/Outlook
+: URL to use when requesting tokens; defaults to Google, must be overridden for use with Microsoft/Outlook.
+  For national clouds, use the appropriate endpoint:
+  US Government: `https://login.microsoftonline.us/{tenant}/oauth2/v2.0/token`;
+  China (21Vianet): `https://login.partner.microsoftonline.cn/{tenant}/oauth2/v2.0/token`
 
 `proxy`
 

--- a/scripts/sasl-xoauth2-tool.in
+++ b/scripts/sasl-xoauth2-tool.in
@@ -147,26 +147,64 @@ def get_token_gmail(client_id:str, client_secret:str, scope:str, output_filename
 ##########
 
 
-OUTLOOK_REDIRECT_URI = "https://login.microsoftonline.com/common/oauth2/nativeclient"
-OUTLOOK_SCOPE = "openid offline_access https://outlook.office.com/SMTP.Send"
+# Predefined cloud configurations for Microsoft 365 national clouds.
+# Each entry maps a cloud name to its login base URL and SMTP scope.
+OUTLOOK_CLOUD_CONFIGS = {
+    "public": {
+        "login_base": "https://login.microsoftonline.com",
+        "scope": "openid offline_access https://outlook.office.com/SMTP.Send",
+    },
+    "usgov": {
+        "login_base": "https://login.microsoftonline.us",
+        "scope": "openid offline_access https://outlook.office365.us/SMTP.Send",
+    },
+    "usgov-dod": {
+        "login_base": "https://login.microsoftonline.us",
+        "scope": "openid offline_access https://outlook.office365.us/SMTP.Send",
+    },
+    "china": {
+        "login_base": "https://login.partner.microsoftonline.cn",
+        "scope": "openid offline_access https://partner.outlook.cn/SMTP.Send",
+    },
+}
 
 
-def outlook_get_authorization_code(client_id:str, tenant:str) -> str:
-    url = f"https://login.microsoftonline.com/{tenant}/oauth2/v2.0/authorize"
+def outlook_get_cloud_config(cloud:str, login_base_override:Optional[str], scope_override:Optional[str]) -> Dict[str,str]:
+    """Resolve cloud config: explicit overrides take precedence over presets."""
+    if cloud not in OUTLOOK_CLOUD_CONFIGS:
+        raise Exception(f"Unknown cloud '{cloud}'. Known clouds: {', '.join(OUTLOOK_CLOUD_CONFIGS.keys())}")
+    config = dict(OUTLOOK_CLOUD_CONFIGS[cloud])
+    if login_base_override:
+        config["login_base"] = login_base_override
+        if not scope_override:
+            print(f"Warning: --login-base is set but --scope is not. The default scope "
+                  f"from the '{cloud}' cloud preset will be used. If your environment "
+                  f"uses a different mail domain, you may also need --scope.",
+                  file=sys.stderr)
+    if scope_override:
+        config["scope"] = scope_override
+    return config
+
+
+def outlook_get_authorization_code(client_id:str, tenant:str, cloud_config:Dict[str,str]) -> str:
+    login_base = cloud_config["login_base"]
+    scope = cloud_config["scope"]
+    redirect_uri = f"{login_base}/common/oauth2/nativeclient"
+    url = f"{login_base}/{tenant}/oauth2/v2.0/authorize"
     query:Dict[str,str] = {}
     query['client_id'] = client_id
     query['response_type'] = 'code'
-    query['redirect_uri'] = OUTLOOK_REDIRECT_URI
+    query['redirect_uri'] = redirect_uri
     query['response_mode'] = 'query'
-    query['scope'] = OUTLOOK_SCOPE
+    query['scope'] = scope
 
     print("Please visit the following link in a web browser, then paste the resulting URL:\n\n" +
           f"{url}?{urllib.parse.urlencode(query)}\n",
           file=sys.stderr)
 
     resulting_url_input:str = input("Resulting URL: ")
-    if OUTLOOK_REDIRECT_URI not in resulting_url_input:
-        raise Exception(f"Resulting URL does not contain expected prefix: {OUTLOOK_REDIRECT_URI}")
+    if redirect_uri not in resulting_url_input:
+        raise Exception(f"Resulting URL does not contain expected prefix: {redirect_uri}")
     resulting_url = urllib.parse.urlparse(resulting_url_input)
     code = urllib.parse.parse_qs(resulting_url.query)
     if "code" not in code:
@@ -174,15 +212,18 @@ def outlook_get_authorization_code(client_id:str, tenant:str) -> str:
     return code["code"][0]
 
 
-def outlook_get_initial_tokens(client_id:str, client_secret:str, tenant:str, code:str) -> Dict[str,Union[str,int]]:
-    url = f"https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
+def outlook_get_initial_tokens(client_id:str, client_secret:str, tenant:str, code:str, cloud_config:Dict[str,str]) -> Dict[str,Union[str,int]]:
+    login_base = cloud_config["login_base"]
+    scope = cloud_config["scope"]
+    redirect_uri = f"{login_base}/common/oauth2/nativeclient"
+    url = f"{login_base}/{tenant}/oauth2/v2.0/token"
     token_request:Dict[str,str] = {}
     token_request['client_id'] = client_id
     if len(client_secret) > 0:
       token_request['client_secret'] = client_secret
-    token_request['scope'] = OUTLOOK_SCOPE
+    token_request['scope'] = scope
     token_request['code'] = code
-    token_request['redirect_uri'] = OUTLOOK_REDIRECT_URI
+    token_request['redirect_uri'] = redirect_uri
     token_request['grant_type'] = 'authorization_code'
     resp = urllib.request.urlopen(
         urllib.request.Request(
@@ -202,10 +243,12 @@ def outlook_get_initial_tokens(client_id:str, client_secret:str, tenant:str, cod
         raise Exception(f"Tokens not found in response: {content}")
 
 
-def outlook_get_initial_tokens_by_device_flow(client_id:str, tenant:str) -> Dict[str,Union[str,int]]:
-    authority = f"https://login.microsoftonline.com/{tenant}"
+def outlook_get_initial_tokens_by_device_flow(client_id:str, tenant:str, cloud_config:Dict[str,str]) -> Dict[str,Union[str,int]]:
+    login_base = cloud_config["login_base"]
+    scope = cloud_config["scope"]
+    authority = f"{login_base}/{tenant}"
     app = msal.PublicClientApplication(client_id, authority=authority)
-    flow = app.initiate_device_flow([OUTLOOK_SCOPE])
+    flow = app.initiate_device_flow([scope])
     if "user_code" not in flow:
         raise Exception("Failed to create device flow. Ensure that public client flows are enabled for the application. Flow: %s" % json.dumps(flow, indent=4))
     print(flow["message"])
@@ -221,12 +264,12 @@ def outlook_get_initial_tokens_by_device_flow(client_id:str, tenant:str) -> Dict
     }
 
 
-def get_token_outlook(client_id:str, client_secret:str, tenant:str, use_device_flow:bool, output_filename:str, input_dict:dict) -> None:
+def get_token_outlook(client_id:str, client_secret:str, tenant:str, use_device_flow:bool, output_filename:str, input_dict:dict, cloud_config:Dict[str,str]) -> None:
     if use_device_flow:
-        tokens = outlook_get_initial_tokens_by_device_flow(client_id, tenant)
+        tokens = outlook_get_initial_tokens_by_device_flow(client_id, tenant, cloud_config)
     else:
-        code = outlook_get_authorization_code(client_id, tenant)
-        tokens = outlook_get_initial_tokens(client_id, client_secret, tenant, code)
+        code = outlook_get_authorization_code(client_id, tenant, cloud_config)
+        tokens = outlook_get_initial_tokens(client_id, client_secret, tenant, code, cloud_config)
     dump_overwrite(tokens, output_filename, input_dict)
 
 ##########
@@ -253,6 +296,7 @@ def subcommand_get_token(args:argparse.Namespace) -> None:
             parser.error("'outlook' service requires 'tenant' argument.")
         if not (args.client_secret or str(args.client_secret) == '') and not args.use_device_flow:
             args.client_secret = input('Please enter OAuth2 client secret (not always required; Azure docs are unclear): ')
+        cloud_config = outlook_get_cloud_config(args.cloud, args.login_base, args.scope)
         get_token_outlook(
             args.client_id,
             args.client_secret,
@@ -260,8 +304,12 @@ def subcommand_get_token(args:argparse.Namespace) -> None:
             args.use_device_flow,
             args.output_file,
             input_dict,
+            cloud_config,
         )
     elif args.service == 'gmail':
+        if args.cloud != 'public' or args.login_base:
+            print("Warning: --cloud and --login-base are only used with the 'outlook' service and will be ignored.",
+                  file=sys.stderr)
         if not args.client_secret:
             args.client_secret = input('Please enter OAuth2 client secret: ')
         if not args.client_secret:
@@ -297,14 +345,28 @@ sp_get_token.add_argument(
     help="required for both services, will prompt the user if blank",
 )
 sp_get_token.add_argument(
-    '--scope',
-    help="required for 'gmail'",
-)
-sp_get_token.add_argument(
     "--use-device-flow",
     default=False,
     action='store_true',
     help="use simplified device flow for Outlook/Azure",
+)
+sp_get_token.add_argument(
+    '--cloud', default='public',
+    choices=list(OUTLOOK_CLOUD_CONFIGS.keys()),
+    help="Microsoft 365 cloud environment (default: public). "
+         "Use 'usgov' for US Government GCC High, 'usgov-dod' for US Government DoD, "
+         "or 'china' for 21Vianet. Only used with 'outlook' service.",
+)
+sp_get_token.add_argument(
+    '--login-base',
+    help="override the Entra login base URL (e.g. https://login.microsoftonline.us). "
+         "Takes precedence over --cloud. Only used with 'outlook' service.",
+)
+sp_get_token.add_argument(
+    '--scope',
+    help="for 'gmail': required OAuth2 scope. "
+         "For 'outlook': override the default scope from --cloud "
+         "(e.g. 'openid offline_access https://outlook.office365.us/SMTP.Send').",
 )
 sp_get_token.add_argument(
     '--overwrite-existing-token',


### PR DESCRIPTION
This pull request adds comprehensive support for Microsoft 365 "national cloud" environments (such as US Government and China/21Vianet) to the `sasl-xoauth2-tool` script and updates the documentation accordingly. It introduces a new `--cloud` flag for selecting the appropriate cloud environment, allows for endpoint and scope overrides, and ensures that both the script and documentation reflect these changes for easier configuration and usage.

These changes make it much easier to use the tool with Microsoft 365 tenants in government and sovereign clouds, reducing manual configuration and potential errors.

**National Cloud Support and Configuration:**

* Added a new `--cloud` flag to the `sasl-xoauth2-tool` for selecting Microsoft 365 cloud environments (public, usgov, usgov-dod, china), with appropriate login endpoints and SMTP scopes automatically set for each environment. Also allows overrides via `--login-base` and `--scope`. (`scripts/sasl-xoauth2-tool.in`, [[1]](diffhunk://#diff-dd942c49ec1301c00dd7e35f04f7d54e1fe9a2669f5bd457dc461f4b5eed9dadL150-R226) [[2]](diffhunk://#diff-dd942c49ec1301c00dd7e35f04f7d54e1fe9a2669f5bd457dc461f4b5eed9dadL299-R370)
* Refactored token acquisition functions to use the resolved cloud configuration, ensuring correct endpoints and scopes are used for authorization and token requests in all supported clouds. (`scripts/sasl-xoauth2-tool.in`, [[1]](diffhunk://#diff-dd942c49ec1301c00dd7e35f04f7d54e1fe9a2669f5bd457dc461f4b5eed9dadL150-R226) [[2]](diffhunk://#diff-dd942c49ec1301c00dd7e35f04f7d54e1fe9a2669f5bd457dc461f4b5eed9dadL205-R251) [[3]](diffhunk://#diff-dd942c49ec1301c00dd7e35f04f7d54e1fe9a2669f5bd457dc461f4b5eed9dadL224-R272) [[4]](diffhunk://#diff-dd942c49ec1301c00dd7e35f04f7d54e1fe9a2669f5bd457dc461f4b5eed9dadR299-R312)

**Documentation Updates:**

* Added detailed documentation on national cloud support, including a table of supported clouds, example configuration files, and instructions for overriding endpoints and scopes. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R362-R408) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R422-R424) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L451-R503)
* Updated the configuration file documentation to clarify how to set the `token_endpoint` for national clouds. (`docs/sasl-xoauth2.conf.5.md`, [docs/sasl-xoauth2.conf.5.mdL51-R54](diffhunk://#diff-4661cb33e1294c998cead6d976b20f72b7ddc0d7a5da60d3c6c5e08789d2a713L51-R54))

**Backward Compatibility and User Guidance:**

* Ensured backward compatibility by defaulting to the public cloud and providing warnings when cloud-specific options are used with unsupported services (e.g., Gmail). (`scripts/sasl-xoauth2-tool.in`, [[1]](diffhunk://#diff-dd942c49ec1301c00dd7e35f04f7d54e1fe9a2669f5bd457dc461f4b5eed9dadR299-R312) [[2]](diffhunk://#diff-dd942c49ec1301c00dd7e35f04f7d54e1fe9a2669f5bd457dc461f4b5eed9dadL299-R370)

