### PR TITLE
Add support for Client Credentials grant type

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -133,6 +133,14 @@ int Config::InitForTesting(const Json::Value &root) {
   return s_config->Init(root);
 }
 
+int Config::SetClientCredentialsForTesting(std::string grant_type, std::string scope){
+  if (s_config){
+    s_config->grant_type_ = grant_type;
+    s_config->client_credentials_scope_ = scope;
+  }
+  return 0;
+}
+
 Config *Config::Get() {
   if (!s_config) {
     Log("sasl-xoauth2: Attempt to fetch before calling Init()!\n");
@@ -149,6 +157,12 @@ int Config::Init(const Json::Value &root) {
     if (err != SASL_OK) return err;
 
     err = Fetch(root, "client_secret", false, &client_secret_);
+    if (err != SASL_OK) return err;
+
+    err = Fetch(root, "grant_type", true, &grant_type_);
+    if (err != SASL_OK) return err;
+
+    err = Fetch(root, "client_credentials_scope", true, &client_credentials_scope_);
     if (err != SASL_OK) return err;
 
     err = Fetch(root, "always_log_to_syslog", true,

--- a/src/config.h
+++ b/src/config.h
@@ -29,11 +29,14 @@ class Config {
 
   static int Init(std::string path = "");
   static int InitForTesting(const Json::Value &root);
+  static int SetClientCredentialsForTesting(std::string grant_type, std::string scope);
 
   static Config *Get();
 
   std::string client_id() const { return client_id_; }
   std::string client_secret() const { return client_secret_; }
+  std::string grant_type() const { return grant_type_; }
+  std::string client_credentials_scope() const { return client_credentials_scope_; }
   bool always_log_to_syslog() const { return always_log_to_syslog_; }
   bool log_to_syslog_on_failure() const { return log_to_syslog_on_failure_; }
   bool log_full_trace_on_failure() const { return log_full_trace_on_failure_; }
@@ -50,6 +53,8 @@ class Config {
 
   std::string client_id_;
   std::string client_secret_;
+  std::string grant_type_ = "refresh";
+  std::string client_credentials_scope_ = "";
   bool always_log_to_syslog_ = false;
   bool log_to_syslog_on_failure_ = true;
   bool log_full_trace_on_failure_ = false;

--- a/src/token_store.cc
+++ b/src/token_store.cc
@@ -109,10 +109,24 @@ int TokenStore::Refresh() {
   const std::string ca_certs_dir =
       override_ca_certs_dir_.value_or(Config::Get()->ca_certs_dir());
 
-  const std::string request =
+  const std::string grant_type =
+      override_grant_type_.value_or(Config::Get()->grant_type());
+
+  const std::string client_credentials_scope =
+      override_client_credentials_scope_.value_or(Config::Get()->client_credentials_scope());
+
+  std::string request =
       std::string("client_id=") + client_id +
       "&client_secret=" + client_secret +
       "&grant_type=refresh_token&refresh_token=" + refresh_;
+
+  if (grant_type == "client_credentials"){
+    request =
+      std::string("client_id=") + client_id +
+      "&client_secret=" + client_secret +
+      "&grant_type=client_credentials&scope=" + client_credentials_scope;
+  }
+
   std::string response;
   long response_code = 0;
   log_->Write("TokenStore::Refresh: token_endpoint: %s",
@@ -199,11 +213,14 @@ int TokenStore::Read() {
     ReadOverride(root, "proxy", &override_proxy_);
     ReadOverride(root, "ca_bundle_file", &override_ca_bundle_file_);
     ReadOverride(root, "ca_certs_dir", &override_ca_certs_dir_);
+    ReadOverride(root, "grant_type", &override_grant_type_);
+    ReadOverride(root, "client_credentials_scope", &override_client_credentials_scope_);
 
     if (root.isMember("refresh_window"))
       override_refresh_window_ = stoi(root["refresh_window"].asString());
 
     refresh_ = root["refresh_token"].asString();
+
     if (root.isMember("access_token"))
       access_ = root["access_token"].asString();
     if (root.isMember("expiry")) expiry_ = stoi(root["expiry"].asString());
@@ -242,6 +259,8 @@ int TokenStore::Write() {
     WriteOverride("proxy", override_proxy_, &root);
     WriteOverride("ca_bundle_file", override_ca_bundle_file_, &root);
     WriteOverride("ca_certs_dir", override_ca_certs_dir_, &root);
+    WriteOverride("grant_type", override_grant_type_, &root);
+    WriteOverride("client_credentials_scope", override_client_credentials_scope_, &root);
 
     if (override_refresh_window_) {
       root["refresh_window"] = std::to_string(*override_refresh_window_);

--- a/src/token_store.h
+++ b/src/token_store.h
@@ -55,6 +55,8 @@ class TokenStore {
   std::optional<std::string> override_proxy_;
   std::optional<std::string> override_ca_bundle_file_;
   std::optional<std::string> override_ca_certs_dir_;
+  std::optional<std::string> override_grant_type_;
+  std::optional<std::string> override_client_credentials_scope_;
   std::optional<int> override_refresh_window_ = 0;
 
   std::string access_;

--- a/src/xoauth2_test.cc
+++ b/src/xoauth2_test.cc
@@ -625,6 +625,53 @@ bool TestFailedPreemptiveTokenRefresh(sasl_client_plug_t plug) {
   return true;
 }
 
+bool TestWithClientCredentials(sasl_client_plug_t plug) {
+  PrintTestName(__func__);
+  SetPasswordToExpiredToken();
+  sasl_xoauth2::SetHttpInterceptForTesting(&DefaultHttpIntercept);
+
+  sasl_utils_t utils = {};
+  utils.free = &FakeFree;
+  utils.getcallback = &FakeGetCallbackAll;
+  utils.malloc = &FakeMalloc;
+
+  void *context = nullptr;
+  TEST_ASSERT_OK(plug.mech_new(nullptr, nullptr, &context));
+  PlugCleanup _(&utils, plug, context);
+
+  sasl_client_params_t params = {};
+  params.utils = &utils;
+  params.canon_user = &FakeCanonUser;
+
+  const char *to_server = nullptr;
+  unsigned int to_server_len = 0;
+  sasl_out_params_t out_params = {};
+
+  bool intercept_called = false;
+  sasl_xoauth2::SetHttpInterceptForTesting(
+      [&intercept_called](sasl_xoauth2::HttpPostOptions options) {
+        *options.response =
+            R"({"access_token": "refreshed_access", "expires_in": 3600})";
+        *options.response_code = 200;
+        intercept_called = true;
+        return SASL_OK;
+      });
+
+  TEST_ASSERT_OK(plug.mech_step(context, &params, nullptr, 0, nullptr,
+                                &to_server, &to_server_len, &out_params));
+  fprintf(stderr, "to_server=[%s], len=%d\n", to_server, to_server_len);
+  TEST_ASSERT(strstr(to_server, "Bearer") != nullptr);
+  TEST_ASSERT(strstr(to_server, "refreshed_access") != nullptr);
+  TEST_ASSERT(strstr(to_server, kUserName.c_str()) != nullptr);
+  TEST_ASSERT(intercept_called);
+
+  TEST_ASSERT_OK(plug.mech_step(context, &params, "", 0, nullptr, &to_server,
+                                &to_server_len, &out_params));
+  TEST_ASSERT(to_server_len == 0);
+
+  return true;
+}
+
 int main(int argc, char **argv) {
   sasl_xoauth2::EnableLoggingForTesting();
 
@@ -662,6 +709,8 @@ int main(int argc, char **argv) {
   TEST_ABORT(TestWithTokenExpiredError(plug));
   TEST_ABORT(TestPreemptiveTokenRefresh(plug));
   TEST_ABORT(TestFailedPreemptiveTokenRefresh(plug));
+  TEST_ASSERT_OK(sasl_xoauth2::Config::SetClientCredentialsForTesting("client_credentials","https://outlook.office365.com/.default"));
+  TEST_ABORT(TestWithClientCredentials(plug));
 
   Cleanup();
   fprintf(stderr, "\nALL TESTS PASS.\n");


### PR DESCRIPTION
If you add the following to /etc/sasl-xoauth2.conf, you can use sasl-xoauth2 using the Client Credentials grant type:

"grant_type": "client_credentials",
"client_credentials_scope": "https://outlook.office365.com/.default",
"token_endpoint": "https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token",

In order for this to work, you'll need to properly configure your Microsoft accounts. Please see the following (long) URL for the steps required:
https://learn.microsoft.com/en-us/exchange/client-developer/legacy-protocols/ how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth# use-client-credentials-grant-flow-to-authenticate-smtp-imap-and-pop-connections

It's critical that you give the Microsoft Entra application the "SMTP.SendAsApp" permission, grant admin consent, and register the Entra application's service principal in Exchange via Exchange Online PowerShell. Note that you cannot finish this step in a browser. You must do it via PowerShell.